### PR TITLE
fix: correct MAX_SUPPLY check in mint()

### DIFF
--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -509,7 +509,7 @@ def mint(receiver: address) -> uint256:
     @return uint256 Computed TokenID of new Portfolio.
     """
 {%- if cookiecutter.max_supply == 'y' %}
-    assert MAX_SUPPLY >= self.totalSupply + 1
+    assert MAX_SUPPLY > self.totalSupply
 {%- endif %} 
 
     assert msg.sender == self.owner or self.isMinter[msg.sender], "Access is denied."

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -509,7 +509,7 @@ def mint(receiver: address) -> uint256:
     @return uint256 Computed TokenID of new Portfolio.
     """
 {%- if cookiecutter.max_supply == 'y' %}
-    assert MAX_SUPPLY >= self.totalSupply
+    assert MAX_SUPPLY >= self.totalSupply + 1
 {%- endif %} 
 
     assert msg.sender == self.owner or self.isMinter[msg.sender], "Access is denied."


### PR DESCRIPTION
Just notice this: it was checking `MAX_SUPPLY >= self.totalSupply` but if both were equal then the assertion would pass and cause `mint()` to run, making `totalSupply > MAX_SUPPLY`