### PR TITLE
Optional royaltyInfo() for ERC721 and mint() fix

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,5 +11,5 @@
     "permitable": "y",
     "royalties": "y",
     "royalty_percentage": "10",
-    "floor_price": "50"
+    "floor_price": 50
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,5 +8,8 @@
     "mintable": "y",
     "max_supply": "y",
     "max_supply_amount": 10000,
-    "permitable": "y"
+    "permitable": "y",
+    "royalties": "y",
+    "royalty_percentage": "10",
+    "floor_price": "50"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,6 +10,5 @@
     "max_supply_amount": 10000,
     "permitable": "y",
     "royalties": "y",
-    "royalty_percentage": 10,
-    "floor_price_eth": 0.5
+    "royalty_percentage": 10
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,5 +10,5 @@
     "max_supply_amount": 10000,
     "permitable": "y",
     "royalties": "y",
-    "royalty_percentage": 10
+    "royalty_percentage": 10.0
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,6 +10,6 @@
     "max_supply_amount": 10000,
     "permitable": "y",
     "royalties": "y",
-    "royalty_percentage": "10",
+    "royalty_percentage": 10,
     "floor_price_eth": 0.5
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,5 +11,5 @@
     "permitable": "y",
     "royalties": "y",
     "royalty_percentage": "10",
-    "floor_price": 50
+    "floor_price_eth": 0.5
 }

--- a/tests/Basic.json
+++ b/tests/Basic.json
@@ -9,6 +9,8 @@
     "mintable": "y",
     "max_supply": "y",
     "max_supply_amount": 3,
-    "permitable": "y"
+    "permitable": "y",
+    "royalties": "y",
+    "royalty_percentage": 10.0
   }
 }

--- a/tests/Mintable.json
+++ b/tests/Mintable.json
@@ -9,7 +9,9 @@
     "mintable": "y",
     "max_supply": "y",
     "max_supply_amount": 3,
-    "permitable": "y"
+    "permitable": "y",
+    "royalties": "y",
+    "royalty_percentage": 10.0
     
   }
 }

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -204,7 +204,7 @@ def __init__():
     self.baseURI = "{{cookiecutter.base_uri}}"
 {%- endif %}
 
-{%- if cookiecutter.floor_price == 'y' %}
+{%- if cookiecutter.floor_price_eth == 'y' %}
     #priced in ETH
     self.floor_price = "{{cookiecutter.floor_price_eth}}"
 {%- endif %}

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -297,7 +297,6 @@ def getApproved(tokenId: uint256) -> address:
 {%- if cookiecutter.permitable == 'y' %}
 ### Royalty integration under the ERC-2981: NFT Royalty Standard
 @external
-@view
 def royaltyInfo(_tokenId: uint256, _salePrice: uint256) -> (address, uint256):
     """
     /// @notice Called with the sale price to determine how much royalty
@@ -310,8 +309,9 @@ def royaltyInfo(_tokenId: uint256, _salePrice: uint256) -> (address, uint256):
     # check creator of contract
     assert msg.sender == self.owner
     # log Payment
-    log RoyalityInfo(_salePrice / ROYALTY_PERCENTAGE, block.timestamp, _salePrice, msg.sender)
-    return self.owner, _salePrice / ROYALTY_PERCENTAGE  # 10 = 10% of salePrice / 20 = 5% of salePrice
+    _royalty: uint256 = convert(_salePrice, decimal) * ROYALTY_PERCENTAGE, uint256 # Percentage that accepts decimals
+    log RoyalityInfo(_royalty, block.timestamp, _salePrice, msg.sender)
+    return self.owner, _royalty
 {%- endif %}
 
 @view

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -285,6 +285,7 @@ def getApproved(tokenId: uint256) -> address:
 
 {%- if cookiecutter.permitable == 'y' %}
 ### Royalty integration under the ERC-2981: NFT Royalty Standard
+@view
 @external
 def royaltyInfo(_tokenId: uint256, _salePrice: uint256) -> (address, uint256):
     """

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -8,9 +8,10 @@ implements: ERC721
 
 ############ ERC-165 #############
 # @dev Static list of supported ERC165 interface ids
-SUPPORTED_INTERFACES: constant(bytes4[{{ 2 + (1 if cookiecutter.metadata == "y" else 0) + (1 if cookiecutter.permitable == "y" else 0) }}]) = [
+SUPPORTED_INTERFACES: constant(bytes4[{{ 3 + (1 if cookiecutter.metadata == "y" else 0) + (1 if cookiecutter.permitable == "y" else 0) }}]) = [
     0x01ffc9a7,  # ERC165 interface ID of ERC165
     0x80ac58cd,  # ERC165 interface ID of ERC721
+    0x2a55205a,  # ERC165 interface ID of ERC2981
 {%- if cookiecutter.metadata == 'y' %}
     0x5b5e139f,  # ERC165 interface ID of ERC721 Metadata Extension
 {%- endif %}
@@ -272,6 +273,10 @@ def getApproved(tokenId: uint256) -> address:
     assert self.idToOwner[tokenId] != empty(address)
     return self.idToApprovals[tokenId]
 
+@view
+@external
+def royaltyInfo(tokenId: uint256, salePrice: uint256) -> (address, uint256):
+    return self.owner, salePrice / 10  # 10% of salePrice
 
 ### TRANSFER FUNCTION HELPERS ###
 

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -157,6 +157,11 @@ MAX_SUPPLY: constant(uint256) = {{cookiecutter.max_supply_amount}}
 
 {%- endif %}
 
+{%- if cookiecutter.royalties == 'y' %}
+# @dev Percentage of royalties for lifetime for the creator
+ROYALTY_PERCENTAGE: constant(uint256) = {{cookiecutter.royalty_percentage}}
+{%- endif %}
+
 @external
 def __init__():
     """
@@ -294,7 +299,7 @@ def getApproved(tokenId: uint256) -> address:
 @external
 @view
 def royaltyInfo(_tokenId: uint256, _salePrice: uint256) -> (address, uint256):
-        """
+    """
     /// @notice Called with the sale price to determine how much royalty
     //          is owed and to whom. Important; Not all marketplaces respect this, e.g. OpenSea
     /// @param _tokenId - the NFT asset queried for royalty information
@@ -305,8 +310,8 @@ def royaltyInfo(_tokenId: uint256, _salePrice: uint256) -> (address, uint256):
     # check creator of contract
     assert msg.sender == self.owner
     # log Payment
-    log RoyalityInfo(salePrice / ROYALTY_PERCENTAGE, block.timestamp, salePrice, msg.sender)
-    return self.owner, salePrice / ROYALTY_PERCENTAGE  # 10 = 10% of salePrice / 20 = 5% of salePrice
+    log RoyalityInfo(_salePrice / ROYALTY_PERCENTAGE, block.timestamp, _salePrice, msg.sender)
+    return self.owner, _salePrice / ROYALTY_PERCENTAGE  # 10 = 10% of salePrice / 20 = 5% of salePrice
 {%- endif %}
 
 @view

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -469,6 +469,7 @@ def _transferFrom(_owner: address, _receiver: address, _tokenId: uint256, _sende
 
     # Log the transfer
     log Transfer(_owner, _receiver, _tokenId)
+    print("Test")
 
 
 @external

--- a/{{cookiecutter.project_name}}/tests/conftest.py
+++ b/{{cookiecutter.project_name}}/tests/conftest.py
@@ -14,7 +14,3 @@ def receiver(accounts):
 @pytest.fixture(scope="session")
 def nft(owner, project):
     return owner.deploy(project.NFT)
-
-@pytest.approx()
-def royalty_percentage():
-    return 10.0

--- a/{{cookiecutter.project_name}}/tests/conftest.py
+++ b/{{cookiecutter.project_name}}/tests/conftest.py
@@ -14,3 +14,7 @@ def receiver(accounts):
 @pytest.fixture(scope="session")
 def nft(owner, project):
     return owner.deploy(project.NFT)
+
+@pytest.approx()
+def royalty_percentage():
+    return 10.0

--- a/{{cookiecutter.project_name}}/tests/test_token.py
+++ b/{{cookiecutter.project_name}}/tests/test_token.py
@@ -129,6 +129,6 @@ def test_uri(nft, owner):
  {%- if cookiecutter.royalties == 'y' %}
 
 def test_royaltyInfo(nft, royalty_percentage):
-    expected_royalty = int({{ {%- cookiecutter.royalty_percentage %} / 100.0 }}  * ape.convert("1 ether", int))
+    expected_royalty = int({{ cookiecutter.royalty_percentage / 100.0 }} * ape.convert("1 ether", int))
     assert nft.royaltyInfo(1, "1 ether") == ape.approx(expected_royalty)
 {%- endif %}

--- a/{{cookiecutter.project_name}}/tests/test_token.py
+++ b/{{cookiecutter.project_name}}/tests/test_token.py
@@ -1,6 +1,5 @@
 import ape
 
-
 def test_erc165(nft):
     # ERC165 interface ID of ERC165
     assert nft.supportsInterface("0x01ffc9a7")
@@ -19,6 +18,11 @@ def test_erc165(nft):
 
     # ERC165 interface ID of ERC4494
     assert nft.supportsInterface("0x5604e225")
+{%- endif %}
+
+{%- if cookiecutter.royalties == 'y' %}
+    # ERC165 interface ID of ERC2981
+    assert nft.supportsInterface("0x2a55205a")
 {%- endif %}
 
 
@@ -121,3 +125,10 @@ def test_uri(nft, owner):
     assert nft.tokenURI(1) == "new base uri/1"
     
     {%- endif %}
+
+ {%- if cookiecutter.royalties == 'y' %}
+
+def test_royaltyInfo(nft, royalty_percentage):
+    expected_royalty = int( {{{%- cookiecutter.royalty_percentage %} / 100.0 }}  * ape.convert("1 ether", int))
+    assert nft.royaltyInfo(1, "1 ether") == ape.approx(expected_royalty)
+{%- endif %}

--- a/{{cookiecutter.project_name}}/tests/test_token.py
+++ b/{{cookiecutter.project_name}}/tests/test_token.py
@@ -129,6 +129,6 @@ def test_uri(nft, owner):
  {%- if cookiecutter.royalties == 'y' %}
 
 def test_royaltyInfo(nft, royalty_percentage):
-    expected_royalty = int( {{{%- cookiecutter.royalty_percentage %} / 100.0 }}  * ape.convert("1 ether", int))
+    expected_royalty = int({{ {%- cookiecutter.royalty_percentage %} / 100.0 }}  * ape.convert("1 ether", int))
     assert nft.royaltyInfo(1, "1 ether") == ape.approx(expected_royalty)
 {%- endif %}

--- a/{{cookiecutter.project_name}}/tests/test_token.py
+++ b/{{cookiecutter.project_name}}/tests/test_token.py
@@ -1,4 +1,5 @@
 import ape
+import pytest
 
 def test_erc165(nft):
     # ERC165 interface ID of ERC165
@@ -128,7 +129,7 @@ def test_uri(nft, owner):
 
  {%- if cookiecutter.royalties == 'y' %}
 
-def test_royaltyInfo(nft, royalty_percentage):
+def test_royaltyInfo(nft):
     expected_royalty = int({{ cookiecutter.royalty_percentage / 100.0 }} * ape.convert("1 ether", int))
-    assert nft.royaltyInfo(1, "1 ether") == ape.approx(expected_royalty)
+    assert nft.royaltyInfo(1, "1 ether") == pytest.approx(expected_royalty)
 {%- endif %}

--- a/{{cookiecutter.project_name}}/tests/test_token.py
+++ b/{{cookiecutter.project_name}}/tests/test_token.py
@@ -131,5 +131,5 @@ def test_uri(nft, owner):
 
 def test_royaltyInfo(nft):
     expected_royalty = int({{ cookiecutter.royalty_percentage / 100.0 }} * ape.convert("1 ether", int))
-    assert nft.royaltyInfo(1, "1 ether") == pytest.approx(expected_royalty)
+    assert nft.royaltyInfo(1, "1 ether")[1] == pytest.approx(expected_royalty)
 {%- endif %}


### PR DESCRIPTION
- Implemented a royaltyInfo() under the [ERC-2981: NFT Royalty Standard](https://eips.ethereum.org/EIPS/eip-2981#optional-royalty-payments) method for marketplaces to send to NFT creators their corresponding royalties.
- Minor fix to the mint() method @notice comment and return
- Deleted unnecessary isMinter() and state var so that only the smart contract owner can mint NFTs.
- Included a constant for adding a royalty %