### PR TITLE
test_token.py bug for new minted tokens

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,5 +10,5 @@
     "max_supply_amount": 10000,
     "permitable": "y",
     "royalties": "y",
-    "royalty_percentage": 10.0
+    "royalty_percentage_in_decimals": 10.0
 }

--- a/tests/Basic.json
+++ b/tests/Basic.json
@@ -11,6 +11,6 @@
     "max_supply_amount": 3,
     "permitable": "y",
     "royalties": "y",
-    "royalty_percentage": 10.0
+    "royalty_percentage_in_decimals": 10.0
   }
 }

--- a/tests/Mintable.json
+++ b/tests/Mintable.json
@@ -11,7 +11,7 @@
     "max_supply_amount": 3,
     "permitable": "y",
     "royalties": "y",
-    "royalty_percentage": 10.0
+    "royalty_percentage_in_decimals": 10.0
     
   }
 }

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -148,7 +148,7 @@ MAX_SUPPLY: constant(uint256) = {{cookiecutter.max_supply_amount}}
 
 {%- if cookiecutter.royalties == 'y' %}
 # @dev Percentage of royalties for lifetime for the creator
-ROYALTY_PERCENTAGE: constant(decimal) = {{cookiecutter.royalty_percentage}}
+ROYALTY_PERCENTAGE: constant(uint256) = {{cookiecutter.royalty_percentage}}
 ROYALTY_TO_APPLY_TO_PRICE: constant(decimal) = {{ ROYALTY_PERCENTAGE / 100.0 }}
 {%- endif %}
 

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -148,7 +148,8 @@ MAX_SUPPLY: constant(uint256) = {{cookiecutter.max_supply_amount}}
 
 {%- if cookiecutter.royalties == 'y' %}
 # @dev Percentage of royalties for lifetime for the creator
-ROYALTY_PERCENTAGE: constant(decimal) = float({{ cookiecutter.royalty_percentage / 100.0 }})
+ROYALTY_PERCENTAGE: constant(decimal) = {{cookiecutter.royalty_percentage}}
+ROYALTY_TO_APPLY_TO_PRICE: constant(decimal) = {{ ROYALTY_PERCENTAGE / 100.0 }}
 {%- endif %}
 
 @external
@@ -297,7 +298,7 @@ def royaltyInfo(_tokenId: uint256, _salePrice: uint256) -> (address, uint256):
     /// @return royaltyAmount - the royalty payment amount for _salePrice
     """
 
-    royalty: uint256 = convert(convert(_salePrice, decimal) * ROYALTY_PERCENTAGE, uint256) # Percentage that accepts decimals
+    royalty: uint256 = convert(convert(_salePrice, decimal) * ROYALTY_TO_APPLY_TO_PRICE, uint256) # Percentage that accepts decimals
     return self.owner, royalty
 {%- endif %}
 

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -542,7 +542,7 @@ def mint(receiver: address) -> bool:
     # Throws if `msg.sender` is not the minter
     assert msg.sender == self.owner or self.isMinter[msg.sender], "Access is denied."
     # Throws if `receiver` is zero address
-    assert _to != empty(address)
+    assert receiver != empty(address)
     # Throws if `totalSupply` count NFTs tracked by this contract is owned by someone
     assert self.idToOwner[self.totalSupply] == empty(address)
     # Create new owner to allocate token

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -149,7 +149,7 @@ MAX_SUPPLY: constant(uint256) = {{cookiecutter.max_supply_amount}}
 {%- if cookiecutter.royalties == 'y' %}
 # @dev Percentage of royalties for lifetime for the creator
 ROYALTY_PERCENTAGE: constant(uint256) = {{cookiecutter.royalty_percentage}}
-ROYALTY_TO_APPLY_TO_PRICE: constant(decimal) = {{ ROYALTY_PERCENTAGE / 100.0 }}
+ROYALTY_TO_APPLY_TO_PRICE: constant(decimal) = ROYALTY_PERCENTAGE / 100.0
 {%- endif %}
 
 @external

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -148,7 +148,7 @@ MAX_SUPPLY: constant(uint256) = {{cookiecutter.max_supply_amount}}
 
 {%- if cookiecutter.royalties == 'y' %}
 # @dev Percentage of royalties for lifetime for the creator
-ROYALTY_PERCENTAGE: constant(decimal) = int({{ convert(cookiecutter.royalty_percentage, decimal) / 100.0 }})
+ROYALTY_PERCENTAGE: constant(decimal) = float({{ cookiecutter.royalty_percentage / 100.0 }})
 {%- endif %}
 
 @external

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -148,7 +148,7 @@ MAX_SUPPLY: constant(uint256) = {{cookiecutter.max_supply_amount}}
 
 {%- if cookiecutter.royalties == 'y' %}
 # @dev Percentage of royalties for lifetime for the creator
-ROYALTY_PERCENTAGE: constant(decimal) = {{ cookiecutter.royalty_percentage / 100 }}
+ROYALTY_PERCENTAGE: constant(decimal) = int({{ cookiecutter.royalty_percentage / 100.0 }})
 {%- endif %}
 
 @external

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -148,7 +148,7 @@ MAX_SUPPLY: constant(uint256) = {{cookiecutter.max_supply_amount}}
 
 {%- if cookiecutter.royalties == 'y' %}
 # @dev Percentage of royalties for lifetime for the creator
-ROYALTY_PERCENTAGE: constant(decimal) = {{ cookiecutter.royalty_percentage / 100.0 }}
+ROYALTY_PERCENTAGE: constant(decimal) = {{ cookiecutter.royalty_percentage / 100 }}
 {%- endif %}
 
 @external

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -548,12 +548,12 @@ def mint(receiver: address) -> bool:
     assert self.idToOwner[self.totalSupply] == empty(address)
     # Create new owner to allocate token
     self.idToOwner[self.totalSupply] = receiver
-    # Change count tracking, `totalSupply` generates id for `tokenId`
-    tokenId: uint256 = self.totalSupply += 1
+    # Change count tracking, `totalSupply` represents id for `tokenId`
+    self.totalSupply += 1
     # Update balance of minter
     self.balanceOf[receiver] += 1
 
-    log Transfer(empty(address), receiver, tokenId)
+    log Transfer(empty(address), receiver, self.totalSupply)
 
     return True
 {%- endif %}

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -148,7 +148,7 @@ MAX_SUPPLY: constant(uint256) = {{cookiecutter.max_supply_amount}}
 
 {%- if cookiecutter.royalties == 'y' %}
 # @dev Percentage of royalties for lifetime for the creator
-ROYALTY_PERCENTAGE: constant(decimal) = int({{ cookiecutter.royalty_percentage / 100.0 }})
+ROYALTY_PERCENTAGE: constant(decimal) = int({{ convert(cookiecutter.royalty_percentage, decimal) / 100.0 }})
 {%- endif %}
 
 @external

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -148,8 +148,7 @@ MAX_SUPPLY: constant(uint256) = {{cookiecutter.max_supply_amount}}
 
 {%- if cookiecutter.royalties == 'y' %}
 # @dev Percentage of royalties for lifetime for the creator
-ROYALTY_PERCENTAGE: constant(uint256) = {{cookiecutter.royalty_percentage}}
-ROYALTY_TO_APPLY_TO_PRICE: constant(decimal) = ROYALTY_PERCENTAGE / 100.0
+ROYALTY_TO_APPLY_TO_PRICE: constant(decimal) = {{ cookiecutter.royalty_percentage_in_decimals/ 100.0 }} 
 {%- endif %}
 
 @external

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -148,7 +148,7 @@ MAX_SUPPLY: constant(uint256) = {{cookiecutter.max_supply_amount}}
 
 {%- if cookiecutter.royalties == 'y' %}
 # @dev Percentage of royalties for lifetime for the creator
-ROYALTY_TO_APPLY_TO_PRICE: constant(decimal) = {{ cookiecutter.royalty_percentage_in_decimals/ 100.0 }} 
+ROYALTY_TO_APPLY_TO_PRICE: constant(decimal) = {{ cookiecutter.royalty_percentage_in_decimals }} / 100.0
 {%- endif %}
 
 @external

--- a/{{cookiecutter.project_name}}/contracts/NFT.vy
+++ b/{{cookiecutter.project_name}}/contracts/NFT.vy
@@ -283,7 +283,7 @@ def getApproved(tokenId: uint256) -> address:
 
 ### TRANSFER FUNCTION HELPERS ###
 
-{%- if cookiecutter.permitable == 'y' %}
+{%- if cookiecutter.royalties == 'y' %}
 ### Royalty integration under the ERC-2981: NFT Royalty Standard
 @view
 @external
@@ -357,6 +357,7 @@ def _transferFrom(owner: address, receiver: address, tokenId: uint256, sender: a
 
     # Change count tracking
     self.balanceOf[owner] -= 1
+    # Add count of token to address
     self.balanceOf[receiver] += 1
 
     # Log the transfer
@@ -538,15 +539,20 @@ def mint(receiver: address) -> bool:
     assert MAX_SUPPLY > self.totalSupply
 {%- endif %} 
 
+    # Throws if `msg.sender` is not the minter
     assert msg.sender == self.owner or self.isMinter[msg.sender], "Access is denied."
-
-    self.totalSupply += 1
-    assert self.idToOwner[self.totalSupply] == empty(address)  # Sanity check
-    
+    # Throws if `receiver` is zero address
+    assert _to != empty(address)
+    # Throws if `totalSupply` count NFTs tracked by this contract is owned by someone
+    assert self.idToOwner[self.totalSupply] == empty(address)
+    # Create new owner to allocate token
     self.idToOwner[self.totalSupply] = receiver
+    # Change count tracking, `totalSupply` generates id for `tokenId`
+    tokenId: uint256 = self.totalSupply += 1
+    # Update balance of minter
     self.balanceOf[receiver] += 1
 
-    log Transfer(empty(address), receiver, self.totalSupply)
+    log Transfer(empty(address), receiver, tokenId)
 
     return True
 {%- endif %}

--- a/{{cookiecutter.project_name}}/tests/test_token.py
+++ b/{{cookiecutter.project_name}}/tests/test_token.py
@@ -128,7 +128,7 @@ def test_uri(nft, owner):
 
 
 def test_royaltyInfo(nft):
-    ROYALTY_PERCENTAGE: ape.convert({{cookiecutter.royalty_percentage}}, float)
-    expected_royalty = int({{ ROYALTY_PERCENTAGE / 100.0 }} * ape.convert("1 ether", int))
+    ROYALTY_PERCENTAGE = float({{cookiecutter.royalty_percentage}})
+    expected_royalty = float({{ ROYALTY_PERCENTAGE / 100.0 }} * ape.convert("1 ether", int))
     assert nft.royaltyInfo(1, "1 ether") == (nft.owner(), pytest.approx(expected_royalty))
 {%- endif %}

--- a/{{cookiecutter.project_name}}/tests/test_token.py
+++ b/{{cookiecutter.project_name}}/tests/test_token.py
@@ -128,6 +128,6 @@ def test_uri(nft, owner):
 
 
 def test_royaltyInfo(nft):
-    expected_royalty = int(ape.convert("{{cookiecutter.royalty_percentage}}", float) / 100.0 * ape.convert("1 ether", int))
+    expected_royalty = float(ape.convert("{{cookiecutter.royalty_percentage}}", float) / 100.0 * ape.convert("1 ether", int))
     assert nft.royaltyInfo(1, "1 ether") == (nft.owner(), pytest.approx(expected_royalty))
 {%- endif %}

--- a/{{cookiecutter.project_name}}/tests/test_token.py
+++ b/{{cookiecutter.project_name}}/tests/test_token.py
@@ -128,6 +128,6 @@ def test_uri(nft, owner):
 
 
 def test_royaltyInfo(nft):
-    expected_royalty = float({{ cookiecutter.royalty_percentage }}/ 100.0 * ape.convert("1 ether", int))
+    expected_royalty = float({{ cookiecutter.royalty_percentage_in_decimals }}/ 100.0 * ape.convert("1 ether", int))
     assert nft.royaltyInfo(1, "1 ether") == (nft.owner(), pytest.approx(expected_royalty))
 {%- endif %}

--- a/{{cookiecutter.project_name}}/tests/test_token.py
+++ b/{{cookiecutter.project_name}}/tests/test_token.py
@@ -128,6 +128,6 @@ def test_uri(nft, owner):
 
 
 def test_royaltyInfo(nft):
-    expected_royalty = float(ape.convert("{{cookiecutter.royalty_percentage}}", float) / 100.0 * ape.convert("1 ether", int))
+    expected_royalty = float({{ cookiecutter.royalty_percentage }}/ 100.0 * ape.convert("1 ether", int))
     assert nft.royaltyInfo(1, "1 ether") == (nft.owner(), pytest.approx(expected_royalty))
 {%- endif %}

--- a/{{cookiecutter.project_name}}/tests/test_token.py
+++ b/{{cookiecutter.project_name}}/tests/test_token.py
@@ -128,7 +128,6 @@ def test_uri(nft, owner):
 
 
 def test_royaltyInfo(nft):
-    ROYALTY_PERCENTAGE = float({{cookiecutter.royalty_percentage}})
-    expected_royalty = float({{ ROYALTY_PERCENTAGE / 100.0 }} * ape.convert("1 ether", int))
+    expected_royalty = int(ape.convert("{{cookiecutter.royalty_percentage}}", float) / 100.0 * ape.convert("1 ether", int))
     assert nft.royaltyInfo(1, "1 ether") == (nft.owner(), pytest.approx(expected_royalty))
 {%- endif %}

--- a/{{cookiecutter.project_name}}/tests/test_token.py
+++ b/{{cookiecutter.project_name}}/tests/test_token.py
@@ -128,6 +128,7 @@ def test_uri(nft, owner):
 
 
 def test_royaltyInfo(nft):
-    expected_royalty = int({{ cookiecutter.royalty_percentage / 100.0 }} * ape.convert("1 ether", int))
+    ROYALTY_PERCENTAGE: ape.convert({{cookiecutter.royalty_percentage}}, float)
+    expected_royalty = int({{ ROYALTY_PERCENTAGE / 100.0 }} * ape.convert("1 ether", int))
     assert nft.royaltyInfo(1, "1 ether") == (nft.owner(), pytest.approx(expected_royalty))
 {%- endif %}

--- a/{{cookiecutter.project_name}}/tests/test_token.py
+++ b/{{cookiecutter.project_name}}/tests/test_token.py
@@ -39,12 +39,12 @@ def test_mint_and_add_minter(nft, owner, receiver):
     nft.mint(receiver,sender=owner)
     assert nft.balanceOf(owner) == 0
     assert nft.balanceOf(receiver) == 1
-    assert nft.ownerOf(1) == receiver.address
+    assert nft.ownerOf(0) == receiver.address
     nft.addMinter(receiver, sender=owner)
     nft.mint(receiver,sender=receiver)
     assert nft.balanceOf(owner) == 0
     assert nft.balanceOf(receiver) == 2
-    assert nft.ownerOf(2) == receiver.address
+    assert nft.ownerOf(1) == receiver.address
 
 
 def test_total_supply(nft, owner):
@@ -58,15 +58,15 @@ def test_transfer(nft, owner, receiver):
     assert nft.balanceOf(receiver) == 0
     nft.mint(owner, sender=owner)
     assert nft.balanceOf(owner) == 1
-    assert nft.ownerOf(1) == owner.address
-    nft.transferFrom(owner, receiver, 1, sender=owner)
+    assert nft.ownerOf(0) == owner.address
+    nft.transferFrom(owner, receiver, 0, sender=owner)
+    assert nft.ownerOf(0) == receiver.address
     assert nft.balanceOf(owner) == 0
     assert nft.balanceOf(receiver) == 1
-    assert nft.ownerOf(1) == receiver.address
-    nft.transferFrom(receiver, owner, 1, sender=receiver)
+    nft.transferFrom(receiver, owner, 0, sender=receiver)
     assert nft.balanceOf(receiver) == 0
     assert nft.balanceOf(owner) == 1
-    assert nft.ownerOf(1) == owner.address
+    assert nft.ownerOf(0) == owner.address
 
 
 def test_incorrect_signer_transfer(nft, owner, receiver):
@@ -74,10 +74,10 @@ def test_incorrect_signer_transfer(nft, owner, receiver):
     assert nft.balanceOf(receiver) == 0
     nft.mint(owner, sender=owner)
     with ape.reverts():
-        nft.transferFrom(owner,receiver,1,sender=receiver)    
+        nft.transferFrom(owner,receiver,0,sender=receiver)    
     assert nft.balanceOf(receiver) == 0
     assert nft.balanceOf(owner) == 1
-    assert nft.ownerOf(1) == owner.address
+    assert nft.ownerOf(0) == owner.address
 
 
 def test_incorrect_signer_minter(nft, owner, receiver):
@@ -96,21 +96,21 @@ def test_approve_transfer(nft, owner, receiver):
     nft.mint(owner, sender=owner)
     assert nft.balanceOf(receiver) == 0
     assert nft.balanceOf(owner) == 1
-    assert nft.ownerOf(1) == owner.address
+    assert nft.ownerOf(0) == owner.address
     
     with ape.reverts():
-        nft.approve(receiver, 1, sender=receiver)
-        nft.transferFrom(owner, receiver, 1, sender=receiver)
+        nft.approve(receiver, 0, sender=receiver)
+        nft.transferFrom(owner, receiver, 0, sender=receiver)
     assert nft.balanceOf(receiver) == 0
     assert nft.balanceOf(owner) == 1
-    assert nft.ownerOf(1) == owner.address
+    assert nft.ownerOf(0) == owner.address
 
-    nft.approve(receiver, 1, sender=owner)
-    assert nft.getApproved(1) == receiver
-    nft.transferFrom(owner, receiver, 1, sender=receiver)
+    nft.approve(receiver, 0, sender=owner)
+    assert nft.getApproved(0) == receiver
+    nft.transferFrom(owner, receiver, 0, sender=receiver)
     assert nft.balanceOf(receiver) == 1
     assert nft.balanceOf(owner) == 0
-    assert nft.ownerOf(1) == receiver.address
+    assert nft.ownerOf(0) == receiver.address
 
 
 def test_uri(nft, owner):


### PR DESCRIPTION
### What I did
- test_token.py is making use of a NFT minted starting with 1 instead of 0.

### How I did it
- Since idToOwner hashmap is where these values are stored in the EVM with empty values, and our tests start minting from 0 instead of 1

### How to verify it
- Download local copy and run `ape template /ERC721`
